### PR TITLE
Only send metadata update once per Java metadata packet

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/Entity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/Entity.java
@@ -262,6 +262,11 @@ public class Entity {
         session.sendUpstreamPacket(updateAttributesPacket);
     }
 
+    /**
+     * Applies the Java metadata to the local Bedrock metadata copy
+     * @param entityMetadata the Java entity metadata
+     * @param session GeyserSession
+     */
     public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
         switch (entityMetadata.getId()) {
             case 0:
@@ -366,10 +371,12 @@ public class Entity {
                 }
                 break;
         }
-
-        updateBedrockMetadata(session);
     }
 
+    /**
+     * Sends the Bedrock metadata to the client
+     * @param session GeyserSession
+     */
     public void updateBedrockMetadata(GeyserSession session) {
         if (!valid) return;
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityMetadataTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/entity/JavaEntityMetadataTranslator.java
@@ -47,5 +47,7 @@ public class JavaEntityMetadataTranslator extends PacketTranslator<ServerEntityM
         for (EntityMetadata metadata : packet.getMetadata()) {
             entity.updateBedrockMetadata(metadata, session);
         }
+
+        entity.updateBedrockMetadata(session);
     }
 }


### PR DESCRIPTION
While this doesn't fix any bugs, it may be a slight performance enhancement as we aren't sending multiple packets per one Java entity metadata packet.