### PR TITLE
ConnectorServerEventHandler: set default packet handler (#1148)

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
+++ b/connector/src/main/java/org/geysermc/connector/network/ConnectorServerEventHandler.java
@@ -108,6 +108,8 @@ public class ConnectorServerEventHandler implements BedrockServerEventHandler {
     public void onSessionCreation(BedrockServerSession bedrockServerSession) {
         bedrockServerSession.setLogging(true);
         bedrockServerSession.setPacketHandler(new UpstreamPacketHandler(connector, new GeyserSession(connector, bedrockServerSession)));
+        // Set the packet codec to default just in case we need to send disconnect packets.
+        bedrockServerSession.setPacketCodec(BedrockProtocol.DEFAULT_BEDROCK_CODEC);
     }
 
     @Override


### PR DESCRIPTION
This allows disconnect packets to be sent and kick unsupported versions of the game.