### PR TITLE
Inventory fixes (#104)

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/BedrockInventoryTransactionTranslator.java
@@ -31,6 +31,7 @@ import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
 import com.github.steveice10.mc.protocol.data.game.entity.player.InteractAction;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerAction;
+import com.github.steveice10.mc.protocol.data.game.window.WindowType;
 import com.github.steveice10.mc.protocol.data.game.world.block.BlockFace;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerActionPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerInteractEntityPacket;
@@ -54,6 +55,7 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
 import org.geysermc.connector.network.translators.inventory.InventoryTranslator;
+import org.geysermc.connector.network.translators.inventory.SmithingInventoryTranslator;
 import org.geysermc.connector.network.translators.item.ItemEntry;
 import org.geysermc.connector.network.translators.item.ItemRegistry;
 import org.geysermc.connector.network.translators.sound.EntitySoundInteractionHandler;
@@ -74,6 +76,14 @@ public class BedrockInventoryTransactionTranslator extends PacketTranslator<Inve
             case INVENTORY_MISMATCH:
                 Inventory inv = session.getInventoryCache().getOpenInventory();
                 if (inv == null) inv = session.getInventory();
+                if (inv.getWindowType() != null && inv.getWindowType() == WindowType.SMITHING) {
+                    if (inv.getItem(0).getId() != 0 && inv.getItem(1).getId() != 0 && inv.getItem(2).getId() != 0) {
+                        // Hack in legacy support for getting items from the smithing table
+                        // For some reason inventory mismatch is called when using client authoritative inventories
+                        SmithingInventoryTranslator.receiveItem(session, inv);
+                        break;
+                    }
+                }
                 InventoryTranslator.INVENTORY_TRANSLATORS.get(inv.getWindowType()).updateInventory(session, inv);
                 InventoryUtils.updateCursor(session);
                 break;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/inventory/SmithingInventoryTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/inventory/SmithingInventoryTranslator.java
@@ -25,9 +25,14 @@
 
 package org.geysermc.connector.network.translators.inventory;
 
+import com.github.steveice10.mc.protocol.data.game.window.ClickItemParam;
+import com.github.steveice10.mc.protocol.data.game.window.WindowAction;
+import com.github.steveice10.mc.protocol.packet.ingame.client.window.ClientWindowActionPacket;
 import com.nukkitx.protocol.bedrock.data.inventory.ContainerId;
 import com.nukkitx.protocol.bedrock.data.inventory.ContainerType;
 import com.nukkitx.protocol.bedrock.data.inventory.InventoryActionData;
+import org.geysermc.connector.inventory.Inventory;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.inventory.updater.CursorInventoryUpdater;
 
 public class SmithingInventoryTranslator extends BlockInventoryTranslator {
@@ -64,6 +69,19 @@ public class SmithingInventoryTranslator extends BlockInventoryTranslator {
                 return 50;
         }
         return super.javaSlotToBedrock(slot);
+    }
+
+    /**
+     * For some reason with client authoritative inventories, the smithing table's output doesn't quite work.
+     * But we can make it """work""" since the client intends to grab an item when it sends a mismatch packet.
+     * This always assumes you're left-clicking and not shift-clicking.
+     * @param session the Bedrock client session
+     * @param inventory the current inventory
+     */
+    public static void receiveItem(GeyserSession session, Inventory inventory) {
+        ClientWindowActionPacket packet = new ClientWindowActionPacket(inventory.getId(), inventory.getTransactionId().incrementAndGet(),
+                2, inventory.getItem(2), WindowAction.CLICK_ITEM, ClickItemParam.LEFT_CLICK);
+        session.sendDownstreamPacket(packet);
     }
 
 }


### PR DESCRIPTION
- Grindstone is now fixed
- Smithing table now 'works' - we can guess when the client wants an output (it sends a inventory mismatch packet) and at least give the player the netherite tool.

Co-authored-by: DoctorMacc <toy.fighter1@gmail.com>